### PR TITLE
Add update command to enable updating by itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ Options:
   -V, --version  Show the version.
 ```
 
+## roc-start update --help
+```
+Update the platform and package repositories and app stubs. Update all, or specify which to update.
+
+Usage:
+  roc-start update [options]
+
+Options:
+  -k, --packages   Update the package repositories.
+  -f, --platforms  Update the platform repositories.
+  -s, --app-stubs  Update the app stubs.
+  -h, --help       Show this help page.
+  -V, --version    Show the version.
+```
+
 [roc_badge]: https://img.shields.io/endpoint?url=https%3A%2F%2Fpastebin.com%2Fraw%2FGcfjHKzb
 [roc_link]: https://github.com/roc-lang/roc
 

--- a/src/ArgParser.roc
+++ b/src/ArgParser.roc
@@ -21,7 +21,7 @@ cliParser =
     }
     |> Cli.finish {
         name: "roc-start",
-        version: "v0.3.3",
+        version: "v0.3.4",
         authors: ["Ian McLerran <imclerran@protonmail.com>"],
         description: "A simple CLI tool for starting a new roc project. Specify your platform and packages by name, and roc-start will create a new .roc file with the latest releases.",
     }

--- a/src/ArgParser.roc
+++ b/src/ArgParser.roc
@@ -13,7 +13,7 @@ baseUsage = Help.usageHelp cliParser.config ["roc-start"] cliParser.textStyle
 cliParser =
     Cli.weave {
         update: <- Opt.flag { short: "u", long: "update", help: "Update the platform and package repositories." },
-        subcommand: <- Subcommand.optional [tuiSubcommand],
+        subcommand: <- Subcommand.optional [tuiSubcommand, updateSubcommand],
         appName: <- Param.maybeStr { name: "app-name", help: "Name your new roc app." },
         platform: <- Param.maybeStr { name: "platform", help: "The platform to use." },
         packages: <- Param.strList { name: "packages", help: "Any packages to use." },
@@ -33,4 +33,16 @@ tuiSubcommand =
         name: "tui",
         description: "Use the TUI app to browse and search for platforms and packages.",
         mapper: Tui,
+    }
+
+updateSubcommand =
+    Cli.weave {
+        doPkgs: <- Opt.flag { short: "k", long: "packages", help: "Update the package repositories." },
+        doPfs: <- Opt.flag { short: "f", long: "platforms", help: "Update the platform repositories." },
+        doStubs: <- Opt.flag { short: "s", long: "app-stubs", help: "Update the app stubs." },
+    }
+    |> Subcommand.finish {
+        name: "update",
+        description: "Update the platform and package repositories and app stubs. Update all, or specify which to update.",
+        mapper: Update,
     }


### PR DESCRIPTION
Previously to run updates, it was necessary to use the `-u` flag, along app name and platform args, or use the `-u` flag and launch the tui. This meant if all you wanted to do was run an update, there was no convenient way to do so. 

To solve this the `update` command was added. The `-u` / `--update` flag is still preserved.