### PR TITLE
Add `.rocstartthemes` file to allow users to define custom themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 !.github/workflows/
 !ci/
 !src_new/
+!themes/
 
 # reignore files
 *.DS_Store

--- a/src/ArgParser.roc
+++ b/src/ArgParser.roc
@@ -6,7 +6,6 @@ import weaver.Opt
 import weaver.Param
 import weaver.SubCmd
 import rtils.StrUtils
-import Theme
 
 ## Usage messages
 # -----------------------------------------------------------------------------
@@ -34,12 +33,8 @@ extended_usage =
 # -----------------------------------------------------------------------------
 
 cli_parser =
-    separator = ", "
-    theme_choices = Theme.theme_names |> Str.join_with(separator)
     { Cli.weave <-
         verbosity: Opt.maybe_str({ short: "v", long: "verbosity", help: "Set the verbosity level to one of: verbose, quiet, or silent." }) |> Cli.map(verbosity_to_log_level),
-        theme: Opt.maybe_str({ long: "theme", help: "Set the color theme to use one of: ${theme_choices}." })
-        |> Cli.map(color_to_theme),
         subcommand: SubCmd.optional([tui_subcommand, update_subcommand, app_subcommand, package_subcommand, upgrade_subcommand, config_subcommand]),
     }
     |> Cli.finish(
@@ -53,10 +48,10 @@ cli_parser =
     )
     |> Cli.assert_valid
 
-color_to_theme = |color|
-    when color is
-        Ok(name) -> Theme.from_name(name) |> Result.map_err(|_| NoTheme)
-        Err(NoValue) -> Err(NoTheme)
+#color_to_theme = |color|
+#    when color is
+#        Ok(name) -> Theme.from_name(name) |> Result.map_err(|_| NoTheme)
+#        Err(NoValue) -> Err(NoTheme)
 
 verbosity_to_log_level = |verbosity|
     when verbosity is
@@ -169,6 +164,7 @@ update_subcommand =
         do_packages: Opt.flag({ short: "k", long: "packages", help: "Update the package repositories." }),
         do_platforms: Opt.flag({ short: "f", long: "platforms", help: "Update the platform repositories." }),
         do_scripts: Opt.flag({ short: "s", long: "scripts", help: "Update the platform scripts." }),
+        do_themes: Opt.flag({ short: "t", long: "themes", help: "Update the available color themes." }),
     }
     |> SubCmd.finish(
         {

--- a/src/Choices.roc
+++ b/src/Choices.roc
@@ -30,7 +30,7 @@ Choices : [
     Package { force : Bool, packages : List { name : Str, version : Str } },
     Upgrade { filename : Str, packages : List { name : Str, version : Str }, platform : [Err [NoPLatformSpecified], Ok { name : Str, version : Str }] },
     Config { theme : Result Str [NoValue], platform : Result Str [NoValue], verbosity : Result Str [NoValue] },
-    Update { do_packages : Bool, do_platforms : Bool, do_scripts : Bool },
+    Update { do_packages : Bool, do_platforms : Bool, do_scripts : Bool, do_themes: Bool },
     NothingToDo,
 ]
 
@@ -90,7 +90,7 @@ to_update = |choices|
             Update(config)
 
         _ ->
-            Update({ do_packages: Bool.false, do_platforms: Bool.false, do_scripts: Bool.false })
+            Update({ do_packages: Bool.false, do_platforms: Bool.false, do_scripts: Bool.false, do_themes: Bool.false })
 
 to_config : Choices -> Choices
 to_config = |choices|
@@ -154,8 +154,10 @@ set_platform = |choices, platform|
                 Upgrade({ config & platform: Err(NoPLatformSpecified) })
             else
                 Upgrade({ config & platform: Ok(platform_name_and_version_with_default(platform)) })
+
         App(config) ->
             App({ config & platform: platform_name_and_version_with_default(platform) })
+
         _ -> choices
 
 get_platform : Choices -> { name : Str, version : Str }
@@ -178,6 +180,7 @@ set_updates = |choices, updates|
                     do_platforms: List.contains(updates, "Platforms"),
                     do_packages: List.contains(updates, "Packages"),
                     do_scripts: List.contains(updates, "Scripts"),
+                    do_themes: List.contains(updates, "Themes"),
                 },
             )
 
@@ -186,11 +189,12 @@ set_updates = |choices, updates|
 get_updates : Choices -> List Str
 get_updates = |choices|
     when choices is
-        Update({ do_platforms, do_packages, do_scripts }) ->
+        Update({ do_platforms, do_packages, do_scripts, do_themes }) ->
             []
             |> |ul| if do_platforms then List.append(ul, "Platforms") else ul
             |> |ul| if do_packages then List.append(ul, "Packages") else ul
             |> |ul| if do_scripts then List.append(ul, "Scripts") else ul
+            |> |ul| if do_themes then List.append(ul, "Themes") else ul
 
         _ -> []
 
@@ -221,11 +225,12 @@ get_config_verbosity = |choices|
 set_config_platform : Choices, Str -> Choices
 set_config_platform = |choices, platform|
     when choices is
-        Config(config) -> 
-            if Str.is_empty(platform) then 
+        Config(config) ->
+            if Str.is_empty(platform) then
                 Config({ config & platform: Err(NoValue) })
             else
                 Config({ config & platform: Ok(platform) })
+
         _ -> choices
 
 get_config_platform : Choices -> Result Str [NoValue]

--- a/src/Dotfile.roc
+++ b/src/Dotfile.roc
@@ -4,11 +4,13 @@ module
         is_file!,
         read_utf8!,
         write_utf8!,
-    } -> [Config, get_config!, load_dotfile!, create_default_dotfile!, default_config, save_to_dotfile!, save_config!]
+        load_themes!,
+    } -> [Config, get_config!, load_dotfile!, load_custom_themes!, create_default_dotfile!, default_config, save_to_dotfile!, save_config!]
 
 import rtils.StrUtils
 import rtils.ListUtils
 import parse.Parse as P
+import json.Json
 import Theme exposing [Theme]
 LogLevel : [Silent, Quiet, Verbose]
 
@@ -50,14 +52,15 @@ load_dotfile! = |{}|
     file_path = "${home}/.rocstartconfig"
     if file_exists!(file_path) then
         file_contents = read_utf8!(file_path) ? |_| FileReadError
-        parse_dotfile(file_contents) |> Result.map_err(|_| InvalidDotFile)
+        theme_list = load_themes!({})
+        parse_dotfile(file_contents, theme_list) |> Result.map_err(|_| InvalidDotFile)
     else
         Err(NoDotFileFound)
 
 file_exists! = |path| is_file!(path) |> Result.with_default(Bool.false)
 
-parse_dotfile : Str -> Result Config [InvalidDotFile]
-parse_dotfile = |str|
+parse_dotfile : Str, List Theme -> Result Config [InvalidDotFile]
+parse_dotfile = |str, theme_list|
     lines = Str.to_utf8(str) |> ListUtils.split_with_delims_tail(|c| c == '\n') |> List.map(Str.from_utf8_lossy)
     verbosity =
         when
@@ -67,7 +70,7 @@ parse_dotfile = |str|
             _ -> default_config.verbosity
     theme =
         when
-            lines |> List.keep_oks(parse_theme)
+            lines |> List.keep_oks(parse_theme(theme_list))
         is
             [colors, ..] -> colors
             _ -> default_config.theme
@@ -79,11 +82,13 @@ parse_dotfile = |str|
             _ -> default_config.platform
     Ok({ verbosity, theme, platform })
 
-parse_theme = |str|
-    themes = Theme.theme_names |> List.map(|s| P.string(s) |> P.lhs(newline))
-    pattern = P.string("theme:") |> P.rhs(P.maybe(P.whitespace)) |> P.rhs(P.one_of(themes))
-    parser = pattern |> P.map(Theme.from_name)
-    parser(str) |> P.finalize |> Result.map_err(|_| InvalidTheme)
+parse_theme = |theme_list|
+    |str|
+        theme_names = theme_list |> List.map(|t| t.name)
+        themes = theme_names |> List.map(|s| P.string(s) |> P.lhs(newline))
+        pattern = P.string("theme:") |> P.rhs(P.maybe(P.whitespace)) |> P.rhs(P.one_of(themes))
+        parser = pattern |> P.map(|name| Theme.from_name(theme_list, name))
+        parser(str) |> P.finalize |> Result.map_err(|_| InvalidTheme)
 
 parse_verbosity = |str|
     verbosity_levels = ["silent", "quiet", "verbose"] |> List.map(|s| P.string(s))
@@ -141,7 +146,7 @@ save_config! = |config|
     contents = config_to_str(config)
     write_utf8!(contents, file_path) |> Result.map_err(|_| FileWriteError)
 
-default_config = { verbosity: Verbose, theme: Theme.roc_c16, platform: { name: "basic-cli", version: "latest" } }
+default_config = { verbosity: Verbose, theme: Theme.default, platform: { name: "basic-cli", version: "latest" } }
 
 save_to_dotfile! : { key : Str, value : Str } => Result {} [HomeVarNotSet, FileWriteError, FileReadError]
 save_to_dotfile! = |{ key, value }|
@@ -169,3 +174,72 @@ save_to_dotfile! = |{ key, value }|
         "${key}: ${value}\n"
         |> write_utf8!(file_path)
         |> Result.map_err(|_| FileWriteError)
+
+load_custom_themes! : {} => Result (List Theme) [HomeVarNotSet, NoDotFileFound, InvalidThemeFile, FileReadError]
+load_custom_themes! = |{}|
+    home_res = env_var!("HOME") |> Result.map_err(|_| HomeVarNotSet)
+    home =
+        if home_res == Err(HomeVarNotSet) then
+            return Ok([])
+        else
+            home_res |> Result.with_default("")
+
+    file_path = "${home}/.rocstartthemes"
+    if file_exists!(file_path) then
+        file_contents =
+            read_utf8!(file_path)
+            |> Result.with_default("")
+            |> Str.to_utf8
+        themes = Decode.from_bytes_partial(file_contents, Json.utf8) |> .result |> Result.with_default([]) |> List.map(json_to_theme)
+        Ok(themes)
+    else
+        Ok([])
+
+JsonTheme : {
+    name : Str,
+    primary : Str,
+    secondary : Str,
+    tertiary : Str,
+    okay : Str,
+    warn : Str,
+    error : Str,
+}
+
+json_to_theme : JsonTheme -> Theme
+json_to_theme = |json_theme| {
+    name: json_theme.name,
+    primary: parse_hex_color(json_theme.primary) |> Result.with_default(Default),
+    secondary: parse_hex_color(json_theme.secondary) |> Result.with_default(Default),
+    tertiary: parse_hex_color(json_theme.tertiary) |> Result.with_default(Default),
+    okay: parse_hex_color(json_theme.okay) |> Result.with_default(Default),
+    warn: parse_hex_color(json_theme.warn) |> Result.with_default(Default),
+    error: parse_hex_color(json_theme.error) |> Result.with_default(Default),
+}
+
+parse_hex_color = |str| hex_color(str) |> P.finalize |> Result.map_err(|_| InvalidHexColor)
+
+hex_color = pound_sign |> P.rhs(P.zip_3(hex_pair, hex_pair, hex_pair)) |> P.map(|(r, g, b)| Rgb((r, g, b)) |> Ok)
+
+pound_sign = P.char |> P.filter(|c| c == '#')
+
+hex_char = P.char |> P.filter(is_hex_digit)
+is_hex_digit = |c| (c >= '0' and c <= '9') or (c >= 'a' and c <= 'f') or (c >= 'A' and c <= 'F')
+
+hex_pair = P.zip(hex_char, hex_char) |> P.map(|(a, b)| num_from_hex_char(a) * 16 + num_from_hex_char(b) |> Ok)
+
+num_from_hex_char = |c|
+    if c >= '0' and c <= '9' then
+        c - 48 |> Num.to_u8
+    else if c >= 'a' and c <= 'f' then
+        c - 87 |> Num.to_u8
+    else if c >= 'A' and c <= 'F' then
+        c - 55 |> Num.to_u8
+    else
+        0
+
+expect num_from_hex_char('0') == 0
+expect num_from_hex_char('9') == 9
+expect num_from_hex_char('a') == 10
+expect num_from_hex_char('f') == 15
+expect num_from_hex_char('A') == 10
+expect num_from_hex_char('F') == 15

--- a/src/ErrorHandlers.roc
+++ b/src/ErrorHandlers.roc
@@ -260,7 +260,7 @@ handle_update_local_repos_error = |{ log_level, theme, colorize }|
         if log_level == Silent then
             Err(Exit(1, ""))
         else
-            err_message = 
+            err_message =
                 when err is
                     FileWriteError -> "Error updating local repositories: file write error."
                     GhAuthError -> "Error updating local repositories: gh cli tool not authenticated - run `gh auth login` to fix."

--- a/src/Model.roc
+++ b/src/Model.roc
@@ -24,6 +24,7 @@ Model : {
     full_menu : List Str,
     selected : List Str,
     # inputs : List ANSI.Input,
+    theme_names : List Str,
     platforms : Dict Str (List RepositoryRelease),
     packages : Dict Str (List RepositoryRelease),
     package_name_map : Dict Str (List Str),
@@ -32,7 +33,7 @@ Model : {
     platform_menu : List Str,
     state : State,
     sender : State,
-    # theme : Theme, 
+    # theme : Theme,
     # including theme in model, whether imported from theme module, or redefined internally using Color causes compiler crash
 }
 
@@ -55,8 +56,8 @@ State : [
 no_choices = NothingToDo
 
 ## Initialize the model
-init : Dict Str (List RepositoryRelease), Dict Str (List RepositoryRelease), { state ?? State } -> Model
-init = |platforms, packages, { state ?? MainMenu({ choices: no_choices }) }|
+init : Dict Str (List RepositoryRelease), Dict Str (List RepositoryRelease), { state ?? State, theme_names ?? List Str } -> Model
+init = |platforms, packages, { state ?? MainMenu({ choices: no_choices }), theme_names ?? ["default"] }|
     package_name_map = RM.build_repo_name_map(Dict.keys(packages))
     platform_name_map = RM.build_repo_name_map(Dict.keys(platforms))
     package_menu = build_repo_menu(package_name_map)
@@ -69,6 +70,7 @@ init = |platforms, packages, { state ?? MainMenu({ choices: no_choices }) }|
         page_first_item: 0,
         menu: menu,
         full_menu: menu,
+        theme_names,
         platforms,
         packages,
         package_name_map,

--- a/src/Theme.roc
+++ b/src/Theme.roc
@@ -1,4 +1,9 @@
-module [Theme, themes, theme_names, from_name, roc_c16, roc, roc_mono, warn_only, no_color, coffee_cat_dark, coffee_cat_light]
+module [
+    Theme,
+    theme_names,
+    from_name,
+    default,
+]
 
 import ansi.Color
 Color : Color.Color
@@ -13,36 +18,14 @@ Theme : {
     warn : Color,
 }
 
-rgb = |r, g, b| Rgb((r, g, b))
+theme_names = |themes| themes |> List.map(.name)
 
-themes : List Theme
-themes = [roc, roc_mono, roc_c16, warn_only, no_color, coffee_cat_dark, coffee_cat_light]
-
-theme_names = themes |> List.map(.name)
-
-from_name = |name|
+from_name = |themes, name|
     List.keep_if(themes, |th| th.name == name) |> List.first |> Result.map_err(|_| InvalidTheme)
 
-roc : Theme
-roc =
-    light_purple = rgb(137, 101, 222)
-    dark_cyan = rgb(57, 171, 219)
-    coral = rgb(222, 100, 124)
-    green = rgb(122, 222, 100)
-    peach = rgb(250, 179, 135)
-    {
-        name: "roc",
-        primary: light_purple,
-        secondary: dark_cyan,
-        tertiary: Standard White,
-        okay: green,
-        warn: peach,
-        error: coral,
-    }
-
-roc_c16 : Theme
-roc_c16 = {
-    name: "roc-c16",
+default : Theme
+default = {
+    name: "default",
     primary: Standard Magenta,
     secondary: Standard Cyan,
     tertiary: Standard White,
@@ -50,78 +33,3 @@ roc_c16 = {
     warn: Standard Yellow,
     error: Standard Red,
 }
-
-roc_mono =
-    light_purple = rgb(137, 101, 222)
-    peach = rgb(250, 179, 135)
-    coral = rgb(222, 100, 124)
-    {
-        name: "roc-mono",
-        primary: light_purple,
-        secondary: light_purple,
-        tertiary: light_purple,
-        okay: light_purple,
-        warn: peach,
-        error: coral,
-    }
-
-warn_only : Theme
-warn_only =
-    coral = rgb(222, 100, 124)
-    peach = rgb(250, 179, 135)
-    {
-        name: "warn-only",
-        primary: Default,
-        secondary: Default,
-        tertiary: Default,
-        okay: Default,
-        warn: peach,
-        error: coral,
-    }
-
-no_color : Theme
-no_color = {
-    name: "no-color",
-    primary: Default,
-    secondary: Default,
-    tertiary: Default,
-    okay: Default,
-    warn: Default,
-    error: Default,
-}
-
-coffee_cat_dark : Theme
-coffee_cat_dark =
-    mauve = rgb(203, 166, 247)
-    blue = rgb(137, 180, 250)
-    sky = rgb(137, 220, 235)
-    red = rgb(243, 139, 168)
-    peach = rgb(250, 179, 135)
-    green = rgb(166, 227, 161)
-    {
-        name: "coffee-cat-dark",
-        primary: mauve,
-        secondary: blue,
-        tertiary: sky,
-        okay: green,
-        warn: peach,
-        error: red,
-    }
-
-coffee_cat_light : Theme
-coffee_cat_light =
-    mauve = rgb(136, 57, 239)
-    blue = rgb(30, 102, 245)
-    teal = rgb(23, 146, 153)
-    red = rgb(210, 15, 57)
-    peach = rgb(254, 100, 11)
-    green = rgb(64, 160, 43)
-    {
-        name: "coffee-cat-light",
-        primary: mauve,
-        secondary: blue,
-        tertiary: teal,
-        okay: green,
-        warn: peach,
-        error: red,
-    }

--- a/src/Theme.roc
+++ b/src/Theme.roc
@@ -16,7 +16,7 @@ Theme : {
 rgb = |r, g, b| Rgb((r, g, b))
 
 themes : List Theme
-themes = [roc_mono, roc_c16, roc, warn_only, no_color, coffee_cat_dark, coffee_cat_light]
+themes = [roc, roc_mono, roc_c16, warn_only, no_color, coffee_cat_dark, coffee_cat_light]
 
 theme_names = themes |> List.map(.name)
 
@@ -125,5 +125,3 @@ coffee_cat_light =
         warn: peach,
         error: red,
     }
-
-

--- a/src/ThemeManager.roc
+++ b/src/ThemeManager.roc
@@ -1,0 +1,112 @@
+module
+    {
+        read_bytes!,
+        write_bytes!,
+        env_var!,
+        is_file!,
+        http_send!,
+    } -> [load_themes!, update_themes!]
+
+import parse.Parse as P
+import json.Json
+import Theme exposing [Theme]
+
+themes_file_url = "https://raw.githubusercontent.com/imclerran/roc-repo/refs/heads/main/themes/.rocstartthemes"
+
+update_themes! = |save_path|
+    file_contents =
+        http_send!(
+            {
+                uri: themes_file_url,
+                method: GET,
+                body: [],
+                headers: [],
+                timeout_ms: TimeoutMilliseconds(3000),
+            },
+        )
+        |> Result.map_ok(|resp| if resp.status == 200 then resp.body else [])
+        |> Result.map_err(|_| HttpError)?
+    if !List.is_empty(file_contents) then
+        write_bytes!(file_contents, save_path)
+    else
+        Ok({})
+
+file_exists! = |path| is_file!(path) |> Result.with_default(Bool.false)
+
+load_themes! : {} => List Theme
+load_themes! = |{}|
+    home_res = env_var!("HOME")
+    home =
+        if home_res == Err(HomeVarNotSet) then
+            return [Theme.default]
+        else
+            home_res |> Result.with_default("")
+
+    file_path = "${home}/.rocstartthemes"
+    if file_exists!(file_path) then
+        themes = read_theme_file!(file_path) |> List.map(json_to_theme)
+        List.append(themes, Theme.default)
+    else
+        update_res = update_themes!(file_path)
+        when update_res is
+            Ok(_) ->
+                themes = read_theme_file!(file_path) |> List.map(json_to_theme)
+                List.append(themes, Theme.default)
+
+            Err(_) ->
+                [Theme.default]
+
+read_theme_file! = |file_path|
+    file_contents =
+        read_bytes!(file_path)
+        |> Result.with_default([])
+    Decode.from_bytes_partial(file_contents, Json.utf8) |> .result |> Result.with_default([])
+
+JsonTheme : {
+    name : Str,
+    primary : Str,
+    secondary : Str,
+    tertiary : Str,
+    okay : Str,
+    warn : Str,
+    error : Str,
+}
+
+json_to_theme : JsonTheme -> Theme
+json_to_theme = |json_theme| {
+    name: json_theme.name,
+    primary: parse_hex_color(json_theme.primary) |> Result.with_default(Default),
+    secondary: parse_hex_color(json_theme.secondary) |> Result.with_default(Default),
+    tertiary: parse_hex_color(json_theme.tertiary) |> Result.with_default(Default),
+    okay: parse_hex_color(json_theme.okay) |> Result.with_default(Default),
+    warn: parse_hex_color(json_theme.warn) |> Result.with_default(Default),
+    error: parse_hex_color(json_theme.error) |> Result.with_default(Default),
+}
+
+parse_hex_color = |str| hex_color(str) |> P.finalize |> Result.map_err(|_| InvalidHexColor)
+
+hex_color = pound_sign |> P.rhs(P.zip_3(hex_pair, hex_pair, hex_pair)) |> P.map(|(r, g, b)| Rgb((r, g, b)) |> Ok)
+
+pound_sign = P.char |> P.filter(|c| c == '#')
+
+hex_char = P.char |> P.filter(is_hex_digit)
+is_hex_digit = |c| (c >= '0' and c <= '9') or (c >= 'a' and c <= 'f') or (c >= 'A' and c <= 'F')
+
+hex_pair = P.zip(hex_char, hex_char) |> P.map(|(a, b)| num_from_hex_char(a) * 16 + num_from_hex_char(b) |> Ok)
+
+num_from_hex_char = |c|
+    if c >= '0' and c <= '9' then
+        c - 48 |> Num.to_u8
+    else if c >= 'a' and c <= 'f' then
+        c - 87 |> Num.to_u8
+    else if c >= 'A' and c <= 'F' then
+        c - 55 |> Num.to_u8
+    else
+        0
+
+expect num_from_hex_char('0') == 0
+expect num_from_hex_char('9') == 9
+expect num_from_hex_char('a') == 10
+expect num_from_hex_char('f') == 15
+expect num_from_hex_char('A') == 10
+expect num_from_hex_char('F') == 15

--- a/src/View.roc
+++ b/src/View.roc
@@ -53,7 +53,7 @@ control_prompts_dict =
     |> Dict.insert(NextPage, "> NEXT")
 
 control_prompts_trunc_dict : Dict UserAction Str
-control_prompts_trunc_dict = 
+control_prompts_trunc_dict =
     Dict.empty({})
     |> Dict.insert(SingleSelect, "ENTER : SEL")
     |> Dict.insert(MultiSelect, "SPACE : SEL")
@@ -75,7 +75,6 @@ control_prompts_trunc_dict =
     |> Dict.insert(Secret, "")
     |> Dict.insert(PrevPage, "<")
     |> Dict.insert(NextPage, ">")
-
 
 ## Shortened control prompts for smaller screens
 control_prompts_short_dict : Dict UserAction Str
@@ -268,7 +267,7 @@ render_package_select = |model, theme|
 render_version_select : Model, Theme -> List ANSI.DrawFn
 render_version_select = |model, theme|
     when model.state is
-        VersionSelect({ repo }) -> 
+        VersionSelect({ repo }) ->
             List.join(
                 [
                     [
@@ -444,7 +443,7 @@ render_package_confirmation = |model, theme|
 render_update_confirmation : Model, Theme -> List ANSI.DrawFn
 render_update_confirmation = |model, theme|
     choices = Model.get_choices(model)
-    updates = choices |> Choices.get_updates |> |lu| if List.is_empty(lu) then ["Platforms", "Packages", "Scripts"] else lu
+    updates = choices |> Choices.get_updates |> |lu| if List.is_empty(lu) then ["Platforms", "Packages", "Scripts", "Themes"] else lu
     List.join(
         [
             [
@@ -507,9 +506,10 @@ render_upgrade_confirmation = |model, theme|
         Upgrade({ filename, platform: maybe_platform, packages: package_repos }) ->
             { platform, render_platform, platform_offset } =
                 when maybe_platform is
-                    Ok({ name, version }) -> 
+                    Ok({ name, version }) ->
                         platform_str = if Str.is_empty(version) then name else "${name}:${version}"
                         { platform: platform_str, render_platform: Bool.true, platform_offset: 1 }
+
                     Err(_) -> { platform: "", render_platform: Bool.false, platform_offset: 0 }
             packages = package_repos |> List.map(|p| if Str.is_empty(p.version) then p.name else "${p.name}:${p.version}")
             List.join(

--- a/themes/.rocstartthemes
+++ b/themes/.rocstartthemes
@@ -1,0 +1,56 @@
+[
+  {
+    "name": "roc",
+    "primary": "#8965DE",
+    "secondary": "#39ABDB",
+    "tertiary": "#FFFFFF",
+    "okay": "#7ADE64",
+    "warn": "#FAB387",
+    "error": "#DE647C"
+  },
+  {
+    "name": "roc-mono",
+    "primary": "#8965DE",
+    "secondary": "#8965DE",
+    "tertiary": "#8965DE",
+    "okay": "#7ADE64",
+    "warn": "#FAB387",
+    "error": "#DE647C"
+  },
+  {
+    "name": "warn-only",
+    "primary": "",
+    "secondary": "",
+    "tertiary": "",
+    "okay": "",
+    "warn": "#FAB387",
+    "error": "#DE647C"
+  },
+  {
+    "name": "no-color",
+    "primary": "",
+    "secondary": "",
+    "tertiary": "",
+    "okay": "",
+    "warn": "",
+    "error": ""
+  },
+  {
+    "name": "cattpuccin-mocha",
+    "primary": "#cba6f7",
+    "secondary": "#89b4fa",
+    "tertiary": "#89dceb",
+    "okay": "#a6e3a1",
+    "warn": "#fab387",
+    "error": "#f38ba8"
+  },
+  {
+    "name": "catppuccin-latte",
+    "primary": "#8839ef",
+    "secondary": "#1e66f5",
+    "tertiary": "#179299",
+    "okay": "#40a02b",
+    "warn": "#fe640b",
+    "error": "#d20f39"
+  }
+]

--- a/themes/.rocstartthemes
+++ b/themes/.rocstartthemes
@@ -39,7 +39,7 @@
     "name": "cattpuccin-mocha",
     "primary": "#cba6f7",
     "secondary": "#89b4fa",
-    "tertiary": "#89dceb",
+    "tertiary": "#cdd6f4",
     "okay": "#a6e3a1",
     "warn": "#fab387",
     "error": "#f38ba8"
@@ -48,7 +48,7 @@
     "name": "catppuccin-latte",
     "primary": "#8839ef",
     "secondary": "#1e66f5",
-    "tertiary": "#179299",
+    "tertiary": "#4c4f69",
     "okay": "#40a02b",
     "warn": "#fe640b",
     "error": "#d20f39"


### PR DESCRIPTION
Color themes are no longer hard coded (besides the default fallback theme) and have been moved into a `.rocstartthemes` file instead. Users can modify this file on their local machine to add their own custom themes.