### PR TITLE
Better release asset identification

### DIFF
--- a/src/ArgParser.roc
+++ b/src/ArgParser.roc
@@ -40,7 +40,7 @@ cli_parser =
     |> Cli.finish(
         {
             name: "roc-start",
-            version: "v0.7.1",
+            version: "v0.7.2",
             authors: ["Ian McLerran <imclerran@protonmail.com>"],
             description: "A simple CLI tool for starting or upgrading roc projects. Specify your platform and packages by name, and roc-start will create a new .roc file or update an existing one with the either the versions you specify, or the latest releases. If no arguments are specified, the TUI app will be launched instead.",
             text_style: Color,

--- a/src/repos/Updater.roc
+++ b/src/repos/Updater.roc
@@ -61,7 +61,7 @@ save_repo_releases! = |releases, save_path|
 
 get_releases_cmd = |repo, alias|
     cmd_new("gh")
-    |> cmd_args(["api", "repos/${repo}/releases?per_page=100", "--paginate", "--jq", ".[] | . as \$release | .assets[]? | select(.name|(endswith(\".tar.br\") or endswith(\".tar.gz\"))) | select(.name | (contains(\"docs\") or contains(\"Source code\")) | not) | [\"${repo}\", \"${alias}\", \$release.tag_name, .browser_download_url] | @csv"])
+    |> cmd_args(["api", "repos/${repo}/releases?per_page=100", "--paginate", "--jq", ".[] | . as \$release | .assets[]? | select(.name|(endswith(\".tar.br\") or endswith(\".tar.gz\"))) | select(.name | split(\".\")[0] | length == 43) | [\"${repo}\", \"${alias}\", \$release.tag_name, .browser_download_url] | @csv"])
 
 get_gh_cmd_stdout = |output|
     stdout = output.stdout |> Str.from_utf8_lossy


### PR DESCRIPTION
Better release asset identification by checking for filename length.
- Release assets are named with a blake3 hash with a length of 43 characters. Use this property in combination with file extension to positively identify release assets.